### PR TITLE
fix bug on edit and show roles in profile page

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -182,13 +182,13 @@ const Profile = () => {
                     roles +
                     '<li>' +
                     categories[parseInt(myroles[i][0])][
-                        parseInt(myroles[i][2])
+                        parseInt(myroles[i].split("-")[1])
                     ] +
                     '</li>'
             );
             setMyRoles((myRoles) => [
                 ...myRoles,
-                myroles[i][0] + '-' + myroles[i][2],
+                myroles[i],
             ]);
         }
         window.onload = await function () {


### PR DESCRIPTION
Fixed a bug when the profile page shows the user's roles corresponding to X-YZ but without the Z.
For example, the user has the role 0-10 (תפקיד כללי) but it shows the role 0-1 (without the '0') which actually means חשמלאי.  